### PR TITLE
Fix ALPN protocol negotiation issue for OABCS sdk's

### DIFF
--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -662,7 +662,8 @@ public final class ProtocolNegotiators {
         SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
         if (handshakeEvent.isSuccess()) {
           SslHandler handler = ctx.pipeline().get(SslHandler.class);
-          if (NEXT_PROTOCOL_VERSIONS.contains(handler.applicationProtocol())) {
+          if (handler.applicationProtocol() == null 
+              || NEXT_PROTOCOL_VERSIONS.contains(handler.applicationProtocol())) {
             // Successfully negotiated the protocol.
             logSslEngineDetails(Level.FINER, ctx, "TLS negotiation succeeded.", null);
 


### PR DESCRIPTION
Original Exception: org.hyperledger.fabric.sdk.exception.ProposalException: getConfigBlock for channel invoice failed with peer peer0.  Status FAILURE, details: Sending proposal to peer0 failed because of: gRPC failure=Status{code=UNKNOWN, description=null, cause=java.lang.Exception: Failed ALPN negotiation: Unable to find compatible protocol.